### PR TITLE
Remove unnecessary `chrome-sandbox` file handling in Cursor extraction

### DIFF
--- a/shell/functions.sh
+++ b/shell/functions.sh
@@ -63,8 +63,6 @@ function setup_cursor() {
     cd /opt/cursor && \
 	sudo /opt/cursor/$FILE_NAME --appimage-extract > /dev/null 2>&1 && \
 	sudo chown -R $USER:$USER /opt/cursor/squashfs-root && \
-	sudo chown root:root /opt/cursor/squashfs-root/chrome-sandbox && \
-	sudo chmod 4755 /opt/cursor/squashfs-root/chrome-sandbox && \
     cd $CURRENT_DIRECTORY
     echo -e "${GREEN}✅ Extracted cursor to: '${EXEC_PATH}'${NC}"
     echo -e "${GREEN}ℹ️ All extracted content is located in: /opt/cursor/squashfs-root/${NC}"

--- a/shell/functions.sh
+++ b/shell/functions.sh
@@ -124,9 +124,6 @@ chmod +x "\$APPDIR/cursor-\${VERSION}-x86_64.AppImage"
 echo "Extracting AppImage (this may take a moment)..."
 cd \$APPDIR && sudo "\$APPDIR/cursor-\${VERSION}-x86_64.AppImage" --appimage-extract > /dev/null 2>&1 && \
     sudo chown $USER:$USER \$APPDIR/squashfs-root && \
-    sudo chown root:root \$APPDIR/squashfs-root/chrome-sandbox && \
-    sudo chmod 4755 \$APPDIR/squashfs-root/chrome-sandbox && \
-    sudo mv \$APPDIR/squashfs-root/AppRun \$APPDIR/squashfs-root/cursor && \
     cd -
 
 echo "Cursor has been updated to version \$VERSION"


### PR DESCRIPTION
**Description:**  
This PR removes the handling of the `/opt/cursor/squashfs-root/chrome-sandbox` file during the extraction process.

### **Reason for the change:**

In the latest stable versions of Cursor, the `chrome-sandbox` file is no longer included. As a result, attempting to change its ownership and permissions caused the following error:
```
chown: cannot access '/opt/cursor/squashfs-root/chrome-sandbox': No such file or directory
```

To resolve this, the following lines have been removed:

- `sudo chown root:root /opt/cursor/squashfs-root/chrome-sandbox`
- `sudo chmod 4755 /opt/cursor/squashfs-root/chrome-sandbox`

Similarly, these lines have been removed in another section of the script to update cursor versión:

- `sudo chown root:root \$APPDIR/squashfs-root/chrome-sandbox`
- `sudo chmod 4755 \$APPDIR/squashfs-root/chrome-sandbox`
