### PR TITLE
fix(curl): curl wasn't following redirects from cursor's api

### DIFF
--- a/shell/functions.sh
+++ b/shell/functions.sh
@@ -110,7 +110,7 @@ APPDIR=/opt/cursor
 API_URL="$URL_CURSOR_DOWN"
 
 # Get the download URL from the API
-APPIMAGE_URL=\$(curl -s "\$API_URL" | grep -o '"downloadUrl":"[^"]*"' | cut -d'"' -f4)
+APPIMAGE_URL=\$(curl -s -L "\$API_URL" | grep -o '"downloadUrl":"[^"]*"' | cut -d'"' -f4)
 
 # Extract the version from the URL
 VERSION=\$(echo "\$APPIMAGE_URL" | grep -o 'Cursor-[0-9.]*' | cut -d'-' -f2)

--- a/shell/functions.sh
+++ b/shell/functions.sh
@@ -6,7 +6,7 @@ function download_cursor() {
 
     # Get the download URL from the API
     echo -e "🔍 ${CYAN}Fetching latest Cursor version...${NC}"
-    APPIMAGE_URL=$(curl -s "$URL_CURSOR_DOWN" | grep -o '"downloadUrl":"[^"]*"' | cut -d'"' -f4)
+    APPIMAGE_URL=$(curl -s -L "$URL_CURSOR_DOWN" | grep -o '"downloadUrl":"[^"]*"' | cut -d'"' -f4)
     
     # Extract the version from the URL
     VERSION=$(echo "$APPIMAGE_URL" | grep -o 'Cursor-[0-9.]*' | cut -d'-' -f2)


### PR DESCRIPTION
**Description:**
This PR fixes an issue where sometimes the curl return "Redirecting..." instead of the actual api response. I was trying to install cursor through the script and it kept saying "http:// isn't a valid method" after debugging I discovered that the api redirects the curl request but it doesn't follow it so I added "-L" flag so that it does.